### PR TITLE
Passing the additional_description from Freighter to UPS

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -607,6 +607,9 @@ module ActiveShipping
           xml.ReasonForExport(options[:reason_for_export] || 'SALE')
           xml.CurrencyCode(options[:currency_code] || 'USD')
           xml.InvoiceNumber(options[:invoice_number])
+          xml.Comments("hamburger")
+          xml.AdditionalComments("grape")
+          xml.AdditionalDescription("berry")
 
           if options[:terms_of_shipment]
             xml.TermsOfShipment(options[:terms_of_shipment])
@@ -618,8 +621,6 @@ module ActiveShipping
             xml.Product do |xml|
               xml.Description("lemon")
               xml.CommodityCode("LIMEADE")
-              xml.AdditionalComments("grape")
-              xml.AdditionalDescription("berry")
               xml.OriginCountryCode(options[:country_of_origin])
               xml.Unit do |xml|
                 xml.Value(package.value / (package.options[:item_count] || 1))

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -612,9 +612,11 @@ module ActiveShipping
             xml.TermsOfShipment(options[:terms_of_shipment])
           end
 
+            # xml.Description(package.options[:description] || options[:description])
+
           packages.each do |package|
             xml.Product do |xml|
-              xml.Description(package.options[:description] || options[:description])
+              xml.Description("lemon")
               xml.CommodityCode(package.options[:commodity_code])
               xml.AdditionalComments(package.options[:additional_comments])
               xml.OriginCountryCode(options[:country_of_origin])

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -607,20 +607,16 @@ module ActiveShipping
           xml.ReasonForExport(options[:reason_for_export] || 'SALE')
           xml.CurrencyCode(options[:currency_code] || 'USD')
           xml.InvoiceNumber(options[:invoice_number])
-          xml.Comments("hamburger")
-          xml.AdditionalComments("grape")
-          xml.AdditionalDescription("berry")
+          xml.Comments(package.options[:comments])
 
           if options[:terms_of_shipment]
             xml.TermsOfShipment(options[:terms_of_shipment])
           end
 
-            # xml.Description(package.options[:description] || options[:description])
-
           packages.each do |package|
             xml.Product do |xml|
-              xml.Description("lemon")
-              xml.CommodityCode("LIMEADE")
+              xml.Description(package.options[:description] || options[:description])
+              xml.CommodityCode(package.options[:commodity_code])
               xml.OriginCountryCode(options[:country_of_origin])
               xml.Unit do |xml|
                 xml.Value(package.value / (package.options[:item_count] || 1))

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -616,7 +616,7 @@ module ActiveShipping
             xml.Product do |xml|
               xml.Description(package.options[:description] || options[:description])
               xml.CommodityCode(package.options[:commodity_code])
-              xml.AdditionalDescription(package.options[:additional_description])
+              xml.AdditionalComments(package.options[:additional_comments])
               xml.OriginCountryCode(options[:country_of_origin])
               xml.Unit do |xml|
                 xml.Value(package.value / (package.options[:item_count] || 1))

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -607,7 +607,7 @@ module ActiveShipping
           xml.ReasonForExport(options[:reason_for_export] || 'SALE')
           xml.CurrencyCode(options[:currency_code] || 'USD')
           xml.InvoiceNumber(options[:invoice_number])
-          xml.Comments(package.options[:comments])
+          xml.Comments(options[:comments])
 
           if options[:terms_of_shipment]
             xml.TermsOfShipment(options[:terms_of_shipment])

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -616,6 +616,7 @@ module ActiveShipping
             xml.Product do |xml|
               xml.Description(package.options[:description] || options[:description])
               xml.CommodityCode(package.options[:commodity_code])
+              xml.AdditionalDescription(package.options[:additional_description])
               xml.OriginCountryCode(options[:country_of_origin])
               xml.Unit do |xml|
                 xml.Value(package.value / (package.options[:item_count] || 1))

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -617,7 +617,7 @@ module ActiveShipping
           packages.each do |package|
             xml.Product do |xml|
               xml.Description("lemon")
-              xml.CommodityCode("lime")
+              xml.CommodityCode("LIMEADE")
               xml.AdditionalComments("grape")
               xml.AdditionalDescription("berry")
               xml.OriginCountryCode(options[:country_of_origin])

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -617,8 +617,9 @@ module ActiveShipping
           packages.each do |package|
             xml.Product do |xml|
               xml.Description("lemon")
-              xml.CommodityCode(package.options[:commodity_code])
-              xml.AdditionalComments(package.options[:additional_comments])
+              xml.CommodityCode("lime")
+              xml.AdditionalComments("grape")
+              xml.AdditionalDescription("berry")
               xml.OriginCountryCode(options[:country_of_origin])
               xml.Unit do |xml|
                 xml.Value(package.value / (package.options[:item_count] || 1))


### PR DESCRIPTION
We need to be able to pass the additional description value up to UPS (which we've received from Freighter & generated in GrailsWeb), which means we need to add an extra field that we were previously not passing up to UPS.

AdditionalDescription is the value that I have seen this referred to as within the UPS documentation, but it's not crazy clear.  Also, this is different from the key mentioned in the comments of the Jira task, being "AdditionalComments", but I have not seen that term appear at all in the UPS documentation, and AdditionalDescription fits their pattern more (re: Description)