### PR TITLE
Revert ups.rb back to 6b5cfd5

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -428,6 +428,9 @@ module ActiveShipping
             end
 
             if options[:prepay]
+              # https://www.ups.com/us/en/help-center/billing-payment/international.page
+              # "Unless otherwise indicated, shipping charges are billed to the shipper's UPS Account Number and the consignee or receiver pays duties & taxes"
+              # Therefore terms_of_shipment=='DDP' must be prepay==false
               xml.PaymentInformation do
                 xml.Prepaid do
                   xml.BillShipper do
@@ -441,10 +444,6 @@ module ActiveShipping
                   # Type '01' means 'Transportation'
                   # This node specifies who will be billed for transportation.
                   xml.Type('01')
-                  build_billing_info_node(xml, options)
-                end
-                xml.ShipmentCharge do
-                  xml.Type('02')
                   build_billing_info_node(xml, options)
                 end
                 if options[:terms_of_shipment] == 'DDP' && options[:international]


### PR DESCRIPTION
Required for https://github.com/stockx/freighter/pull/122.

The issue with submitting `prepay = false` right now is we're guaranteed to be taking on the duties and taxes as the sender (DDP). There is a `terms_of_shipment = 'DDP'` flag that when set adds a duplicate `ShipmentCharge` and causes a validation fail on UPS' end. The default here should be DDU (receiver will pay duties and taxes), the `ShipmentCharge` should only be added with `terms_of_shipment = 'DDP'` flag.