### PR TITLE
LOC-12: Support character set label specification option

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -511,6 +511,8 @@ module ActiveShipping
           label_format = options[:label_format] ? options[:label_format].upcase : 'GIF'
           label_size = options[:label_size] ? options[:label_size] : [4, 6]
 
+          character_set = options[:character_set] ? options[:character_set] : 'eng'
+
           xml.LabelSpecification do
             xml.LabelStockSize do
               xml.Height(label_size[0])
@@ -528,6 +530,8 @@ module ActiveShipping
                 xml.Code(label_format)
               end
             end
+
+            xml.CharacterSet(character_set)
           end
         end
       end


### PR DESCRIPTION
Epic: https://stockx-services.atlassian.net/browse/LOC-12
Specific card: https://stockx-services.atlassian.net/browse/LOC-201

# Proposed Changes
Adds the character set option to the shipment request XML body

See pages 130-131 of the UPS Shipping Package XML Developer Guide for more information on the possible character set values.