### PR TITLE
DL-17: Add processing fee and freight to the UPS commercial invoices

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -620,7 +620,6 @@ module ActiveShipping
 
           xml.OtherCharges do
             xml.MonetaryValue(options[:shipping_amount])
-            xml.Description('')
           end
 
           if options[:terms_of_shipment]

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -620,6 +620,7 @@ module ActiveShipping
 
           xml.OtherCharges do
             xml.MonetaryValue(options[:shipping_amount])
+            xml.Description('Processing Fee')
           end
 
           if options[:terms_of_shipment]

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -186,11 +186,9 @@ module ActiveShipping
 
       # STEP 1: Confirm.  Validation step, important for verifying price.
       confirm_request = build_shipment_request(origin, destination, packages, options)
-      puts confirm_request.inspect
       logger.debug(confirm_request) if logger
 
       confirm_response = commit(:ship_confirm, save_request(access_request + confirm_request), (options[:test] || false))
-      puts confirm_response.inspect
       logger.debug(confirm_response) if logger
 
       # ... now, get the digest, it's needed to get the label.  In theory,

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -186,9 +186,11 @@ module ActiveShipping
 
       # STEP 1: Confirm.  Validation step, important for verifying price.
       confirm_request = build_shipment_request(origin, destination, packages, options)
+      puts confirm_request.inspect
       logger.debug(confirm_request) if logger
 
       confirm_response = commit(:ship_confirm, save_request(access_request + confirm_request), (options[:test] || false))
+      puts confirm_response.inspect
       logger.debug(confirm_response) if logger
 
       # ... now, get the digest, it's needed to get the label.  In theory,

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -615,11 +615,11 @@ module ActiveShipping
           xml.Comments(options[:comments])
 
           xml.FreightCharges do
-            xml.MonetaryValue(options[:processing_fee])
+            xml.MonetaryValue(options[:shipping_amount])
           end
 
           xml.OtherCharges do
-            xml.MonetaryValue(options[:shipping_amount])
+            xml.MonetaryValue(options[:processing_fee])
             xml.Description('Processing')
           end
 

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -612,6 +612,14 @@ module ActiveShipping
           xml.InvoiceNumber(options[:invoice_number])
           xml.Comments(options[:comments])
 
+          xml.FreightCharges do
+            xml.MonetaryValue(options[:processing_fee])
+          end
+
+          xml.OtherCharges do
+            xml.MonetaryValue(options[:shipping_amount])
+          end
+
           if options[:terms_of_shipment]
             xml.TermsOfShipment(options[:terms_of_shipment])
           end

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -618,6 +618,7 @@ module ActiveShipping
 
           xml.OtherCharges do
             xml.MonetaryValue(options[:shipping_amount])
+            xml.Description('')
           end
 
           if options[:terms_of_shipment]

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -613,12 +613,12 @@ module ActiveShipping
           xml.Comments(options[:comments])
 
           xml.FreightCharges do
-            xml.MonetaryValue(options[:shipping_amount])
+            xml.MonetaryValue(options[:shipping_amount]) # Required, valid char 0-9, up to 2 decimal places, 15 char max including decimal
           end
 
           xml.OtherCharges do
-            xml.MonetaryValue(options[:processing_fee])
-            xml.Description('Processing')
+            xml.MonetaryValue(options[:processing_fee]) # Required, valid char 0-9, up to 2 decimal places, 15 char max including decimal
+            xml.Description('Processing') # Required, 1-10 chars
           end
 
           if options[:terms_of_shipment]

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -620,7 +620,7 @@ module ActiveShipping
 
           xml.OtherCharges do
             xml.MonetaryValue(options[:shipping_amount])
-            xml.Description('Processing Fee')
+            xml.Description('Processing')
           end
 
           if options[:terms_of_shipment]


### PR DESCRIPTION
# Related Tickets
https://stockx-services.atlassian.net/browse/DL-17
Related Freighter PR: https://github.com/stockx/freighter/pull/314

# Changes proposed
Add Shipping Fees and Processing Fees to the UPS commercial invoice


#### Expected Output
- Shipping fees will appear under the 'Freight' line on the UPS commercial invoice
- Processing fees will appear under the 'Other' line on the UPS commercial invoice

![image-20200102-163209](https://user-images.githubusercontent.com/19169999/71924780-b2d14480-315d-11ea-820f-6ca9c3571022.png)


#### New Routes
NA


#### Caveats
NA