### PR TITLE
DL-2832 Added Gemfile for activesupport 5.1 and allow activesupport 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ rvm:
 - "2.2.2"
 - "2.3.1"
 - "2.4.0"
+- "2.5.0"
 
 gemfile:
 - gemfiles/activesupport42.gemfile
 - gemfiles/activesupport50.gemfile
+- gemfiles/activesupport51.gemfile
 - gemfiles/activesupport_master.gemfile
 
 matrix:

--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_path  = "lib"
 
-  s.add_dependency("measured", "~> 1.6.0")
-  s.add_dependency("activesupport", ">= 4.2", "< 5.2.0")
+  s.add_dependency("measured", ">= 1.6.0")
+  s.add_dependency("activesupport", ">= 4.2", "< 6.1")
   s.add_dependency("active_utils", "~> 3.3.1")
   s.add_dependency("nokogiri", ">= 1.6")
 

--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_path  = "lib"
 
-  s.add_dependency("measured", ">= 1.6.0")
+  s.add_dependency("measured", "~> 1.6.0")
   s.add_dependency("activesupport", ">= 4.2", "< 6.1")
   s.add_dependency("active_utils", "~> 3.3.1")
   s.add_dependency("nokogiri", ">= 1.6")

--- a/gemfiles/activesupport51.gemfile
+++ b/gemfiles/activesupport51.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem 'activesupport', '~> 5.1.0'


### PR DESCRIPTION
# Purpose

activesupport is a toolkit of support libraries and Ruby core extensions extracted from the Rails framework.

Affected versions of this package are vulnerable to Deserialization of Untrusted Data via the MemCacheStore and RedisCacheStore. when untrusted user input is written to the cache store using the raw: true parameter, re-reading the result from the cache can evaluate the user input as a Marshalled object instead of plain text.

Freighter uses this gem and activesupport versioning has a vulnerability in its current version range.

# JIRA
https://stockx-services.atlassian.net/browse/DL-2382

# Changes:
- Added Gemfile for activesupport 5.1 and allow activesupport 6