### PR TITLE
(chore) Update testing suite and add CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2.1
+orbs:
+  ruby: circleci/ruby@0.1.2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.6.3-stretch-node
+    executor: ruby/default
+    steps:
+      - checkout
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      - ruby/bundle-install
+      - run:
+          name: Running Unit Tests
+          command: bundle exec rake test:unit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ActiveShipping [![Build status](https://travis-ci.org/Shopify/active_shipping.svg?branch=master)](https://travis-ci.org/Shopify/active_shipping)
+# [![CircleCI](https://circleci.com/gh/stockx/active_shipping.svg?style=svg)](https://circleci.com/gh/stockx/active_shipping)
 
 This library interfaces with the web services of various shipping carriers. The goal is to abstract the features that are most frequently used into a pleasant and consistent Ruby API:
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@ require 'bundler/setup'
 
 require 'minitest/autorun'
 require "minitest/reporters"
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'timecop'
 require 'business_time'
 

--- a/test/unit/carriers/canada_post_pws_test.rb
+++ b/test/unit/carriers/canada_post_pws_test.rb
@@ -10,17 +10,17 @@ class CanadaPostPwsTest < ActiveSupport::TestCase
   def test_get_sanitized_postal_code_location_nil
     postal_code = @cp.send(:get_sanitized_postal_code, nil)
 
-    assert_equal nil, postal_code
+    assert_nil postal_code
   end
 
   def test_get_sanitized_postal_code_postal_code_nil
     location = Location.new(name: 'Test test')
 
-    assert_equal nil, location.postal_code
+    assert_nil location.postal_code
 
     postal_code = @cp.send(:get_sanitized_postal_code, location)
 
-    assert_equal nil, postal_code
+    assert_nil postal_code
   end
 
   def test_get_sanitized_postal_code_spaces

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -384,7 +384,7 @@ class USPSTest < ActiveSupport::TestCase
   end
 
   def test_strip_9_digit_zip_codes
-    request = URI.decode(@carrier.send(:build_us_rate_request, package_fixtures[:book], "90210-1234", "123456789"))
+    request = CGI.unescape(@carrier.send(:build_us_rate_request, package_fixtures[:book], "90210-1234", "123456789"))
     assert !(request =~ /\>90210-1234\</)
     assert request =~ /\>90210\</
     assert !(request =~ /\>123456789\</)
@@ -392,7 +392,7 @@ class USPSTest < ActiveSupport::TestCase
   end
 
   def test_strip_9_digit_zip_codes_world_rates
-    request = URI.decode(@carrier.send(:build_world_rate_request, location_fixtures[:beverly_hills_9_zip],
+    request = CGI.unescape(@carrier.send(:build_world_rate_request, location_fixtures[:beverly_hills_9_zip],
                                         package_fixtures[:book], location_fixtures[:auckland], {}))
     refute_match /\<OriginZip\>90210-1234/, request
     assert_match /\<OriginZip\>90210/, request

--- a/test/unit/location_test.rb
+++ b/test/unit/location_test.rb
@@ -149,7 +149,7 @@ class LocationTest < ActiveSupport::TestCase
   end
 
   test "#to_hash has the expected attributes" do
-    expected = %w(address1 address2 address3 address_type city company_name country fax name phone postal_code province)
+    expected = %w(address1 address2 address3 address_type city company_name country email fax name phone postal_code province tin)
 
     assert_equal expected, @location.to_hash.stringify_keys.keys.sort
   end


### PR DESCRIPTION
# Purpose
- To update testing suite so future developers can push changes and run tests as part of CI.

# Changes
- Update mocha/mini_test lib reference to be valid.
- Update nil assertions that will fail in later minitest version 6.
- Use CGI.unescape vs deprecated URI.unescape method.
- Update failing spec due to new fields added to Location model.
- Add CircleCI config to run unit tests.

# Testing
- Run `bundle exec rake test:unit` - Specs pass ✅ 
- Run `bundle exec rake test:remote` with local credentials -Specs pass ✅  