### PR TITLE
DL -2666 Temporarily stub Northern Ireland response

### DIFF
--- a/lib/active_shipping/location.rb
+++ b/lib/active_shipping/location.rb
@@ -51,6 +51,13 @@ module ActiveShipping #:nodoc:
           :numeric => '724'
         }
         ActiveUtils::Country.new(ic_country_options)
+      elsif (options[:country] == 'XI')
+        xi_country_options = {
+          :alpha2 => 'XI',
+          :name => 'Northern Ireland'
+          # TODO: add alpha 3 and numeric
+        }
+        ActiveUtils::Country.new(xi_country_options)
       else
         ActiveUtils::Country.find(options[:country])
       end

--- a/lib/active_shipping/location.rb
+++ b/lib/active_shipping/location.rb
@@ -57,7 +57,6 @@ module ActiveShipping #:nodoc:
           :name => 'Northern Ireland',
           :alpha3 => 'GBR', # TODO: update alpha3
           :numeric => '826' # TODO: update numeric
-
         }
         ActiveUtils::Country.new(xi_country_options)
       else

--- a/lib/active_shipping/location.rb
+++ b/lib/active_shipping/location.rb
@@ -54,8 +54,10 @@ module ActiveShipping #:nodoc:
       elsif (options[:country] == 'XI')
         xi_country_options = {
           :alpha2 => 'XI',
-          :name => 'Northern Ireland'
-          # TODO: add alpha 3 and numeric
+          :name => 'Northern Ireland',
+          :alpha3 => 'GBR', # TODO: update alpha3
+          :numeric => '826' # TODO: update numeric
+
         }
         ActiveUtils::Country.new(xi_country_options)
       else

--- a/lib/active_shipping/location.rb
+++ b/lib/active_shipping/location.rb
@@ -53,7 +53,7 @@ module ActiveShipping #:nodoc:
         ActiveUtils::Country.new(ic_country_options)
       elsif (options[:country] == 'XI')
         xi_country_options = {
-          :alpha2 => 'XI',
+          :alpha2 => 'GB', # TODO: update alpha2
           :name => 'Northern Ireland',
           :alpha3 => 'GBR', # TODO: update alpha3
           :numeric => '826' # TODO: update numeric

--- a/test/unit/location_test.rb
+++ b/test/unit/location_test.rb
@@ -25,6 +25,13 @@ class LocationTest < ActiveSupport::TestCase
     assert_equal 'CA', @location.country_code(:alpha2)
   end
 
+  test "#initialize is able to initialize with Northern Ireland iso2" do
+    northern_ireland = ActiveShipping::Location.new({country: 'XI'})
+    assert_equal 'XI', northern_ireland.country_code(:alpha2)
+    assert_equal 'GBR', northern_ireland.country_code(:alpha3)
+    assert_equal '826', northern_ireland.country_code(:numeric)
+  end
+
   test ".from sets up the location from a hash" do
     location = Location.from(@attributes_hash)
 

--- a/test/unit/location_test.rb
+++ b/test/unit/location_test.rb
@@ -27,7 +27,7 @@ class LocationTest < ActiveSupport::TestCase
 
   test "#initialize is able to initialize with Northern Ireland iso2" do
     northern_ireland = ActiveShipping::Location.new({country: 'XI'})
-    assert_equal 'XI', northern_ireland.country_code(:alpha2)
+    assert_equal 'GB', northern_ireland.country_code(:alpha2)
     assert_equal 'GBR', northern_ireland.country_code(:alpha3)
     assert_equal '826', northern_ireland.country_code(:numeric)
   end


### PR DESCRIPTION
### Purpose

Due to Brexit, we will now be categorizing the United Kingdom (GB) and Northern Ireland as two separate countries. Northern Ireland has already been assigned the ISO 3166-1 alpha-2 code of 'XI'. We still need to confirm the ISO 3166-1 alpha-3 and ISO 3166-1 numeric codes, but for the time being, we are just going to use the same as GB.

### Changes

- Temporarily stub Northern Ireland response

### Testing

- Test local gem build with Northern Ireland.